### PR TITLE
change gsub! with gsub in identity_token private key method

### DIFF
--- a/lib/layer/identity_token.rb
+++ b/lib/layer/identity_token.rb
@@ -47,7 +47,7 @@ module Layer
     def private_key
       # Cloud66 stores newlines as \n instead of \\n
       key = ENV['LAYER_PRIVATE_KEY'].dup
-      OpenSSL::PKey::RSA.new(key.gsub!("\\n","\n"))
+      OpenSSL::PKey::RSA.new(key.gsub("\\n","\n"))
     end
   end
 end


### PR DESCRIPTION
Changing to gsub because if gsub! used and the substitution did not find the given char it returned nil